### PR TITLE
docs(examples): add complete working demo submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build/
 submission.json
 audit.json
 verdict.json
+
+# example submission model (downloaded, ~100 MB)
+examples/demo-submission/model/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ To profile model executions correctly, the tool relies on native binaries:
 
 ## 🧪 Usage
 
+A complete working example submission (metadata + model download script) lives in [`examples/demo-submission/`](examples/demo-submission/) — copy it to get started.
+
 The profiler runs in two primary modes:
 
 ### 1. Participant Mode (Gate 1)

--- a/examples/demo-submission/README.md
+++ b/examples/demo-submission/README.md
@@ -1,0 +1,38 @@
+# Demo submission
+
+A complete, working example of the submission directory the profiler expects:
+`metadata.json` plus the model file it points to. Use it to see the profiler
+run end to end before building your own submission.
+
+```bash
+# 1. Fetch the demo model (~100 MB, SmolLM2-135M Q4_K_M)
+./download_model.sh
+
+# 2. Run the profiler against this directory
+adtc-profiler run \
+  --submission . \
+  --mode participant \
+  --output submission.json
+```
+
+Add `--skip-accuracy` while iterating for a much faster loop; ship the output
+of a full run.
+
+## Adapting it for your team
+
+Copy this directory and edit `metadata.json`:
+
+- **All top-level fields are required** and no extra fields are allowed
+  (`additionalProperties: false`) — the profiler validates before benchmarking
+  and tells you exactly what's wrong.
+- Replace the `submitter` placeholders with your real details.
+- `test_prompts` must contain **exactly two** prompts — judges use them
+  alongside domain and hidden prompts.
+- `model.parameters_estimate` is checked against the actual parameter count
+  read from your GGUF's tensor table (±15%) — state it honestly.
+- `_runtime.model_path` tells the profiler where your model file lives,
+  relative to this directory. Underscore-prefixed keys never appear in the
+  report.
+
+The canonical field-by-field contract is
+[`src/adtc_profiler/schema/adtc-profiler.schema.json`](../../src/adtc_profiler/schema/adtc-profiler.schema.json).

--- a/examples/demo-submission/download_model.sh
+++ b/examples/demo-submission/download_model.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Download SmolLM2-135M-Instruct (Q4_K_M GGUF, ~100 MB) — the demo model this
+# example submission points at. Idempotent.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODEL_DIR="$HERE/model"
+MODEL_FILE="$MODEL_DIR/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+MODEL_URL="https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+
+mkdir -p "$MODEL_DIR"
+
+if [[ -f "$MODEL_FILE" ]]; then
+  echo "model already present at $MODEL_FILE — skipping download"
+  exit 0
+fi
+
+echo "downloading $MODEL_URL -> $MODEL_FILE (~100 MB)…"
+if command -v curl >/dev/null 2>&1; then
+  curl -L --fail --progress-bar -o "$MODEL_FILE.partial" "$MODEL_URL"
+elif command -v wget >/dev/null 2>&1; then
+  wget --show-progress -O "$MODEL_FILE.partial" "$MODEL_URL"
+else
+  echo "neither curl nor wget available" >&2
+  exit 1
+fi
+mv "$MODEL_FILE.partial" "$MODEL_FILE"
+echo "done: $MODEL_FILE"

--- a/examples/demo-submission/metadata.json
+++ b/examples/demo-submission/metadata.json
@@ -1,0 +1,37 @@
+{
+  "team_id": "demo-team",
+  "domain": "coding_assistants",
+  "language_scope": ["en"],
+  "african_alpha_claim": false,
+  "budget_laptop_claim": true,
+  "submitter": {
+    "name": "Your Name",
+    "email": "you@example.org",
+    "github_handle": "your-github-handle"
+  },
+  "cross_disciplinary_pairing": {
+    "discipline": "education",
+    "load_bearing": true,
+    "description": "Coding assistant used in classroom settings"
+  },
+  "test_prompts": [
+    {
+      "prompt_id": "tp_001",
+      "prompt": "Write a Python function that reads a CSV file and returns the column with the highest mean value."
+    },
+    {
+      "prompt_id": "tp_002",
+      "prompt": "Explain the difference between a list and a tuple in Python, and give one example where each is the better choice."
+    }
+  ],
+  "model": {
+    "name": "SmolLM2-135M-Instruct-Q4_K_M",
+    "runtime": "llama.cpp",
+    "quantization": "GGUF Q4_K_M",
+    "parameters_estimate": "135M",
+    "packaging": "binary_bundle"
+  },
+  "_runtime": {
+    "model_path": "model/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+  }
+}


### PR DESCRIPTION
Adds `examples/demo-submission/` — a complete, working submission directory participants can copy:

- `metadata.json` with every required field and obvious placeholders for `submitter` (schema-valid as shipped, so the end-to-end demo works before any editing)
- `download_model.sh` fetching the SmolLM2-135M Q4_K_M demo GGUF (~100 MB, idempotent)
- `README.md` with run instructions and the field-by-field rules people actually trip on (exactly-2 `test_prompts`, no extra fields, ±15% fraud-checked `parameters_estimate`, `_runtime.model_path` semantics)

Root README links it from the Usage section; the downloaded model directory is gitignored.

Verified: `adtc-profiler run --submission examples/demo-submission --mode participant` validates and profiles cleanly with the current main.

Context: the community walkthrough video will point at this directory, and the old `adtc-2026-profiler` fixtures predate the current schema (missing `submitter`/`test_prompts`) so they can't serve as examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)